### PR TITLE
fix: support markup syntaxes in format_text

### DIFF
--- a/src/format_text.rs
+++ b/src/format_text.rs
@@ -55,7 +55,7 @@ pub fn format_text(file_path: &Path, input_text: &str, config: &Configuration) -
       let printed = formatted.print()?;
       printed.into_code()
     }
-    Some("js" | "jsx" | "ts" | "tsx" | "cjs" | "mjs" | "cts" | "mts") => {
+    Some("js" | "jsx" | "ts" | "tsx" | "cjs" | "mjs" | "cts" | "mts" | "astro" | "svelte" | "vue") => {
       let Ok(syntax) = JsFileSource::try_from(file_path) else {
         return Ok(None);
       };


### PR DESCRIPTION
Allows upstream packages like [markup_fmt](https://github.com/g-plane/markup_fmt) pass extensions for files that use markup/frontmatter syntaxes.

Closes #15 

