### PR TITLE
feat: support css.tailwindDirectives option

### DIFF
--- a/deployment/schema.json
+++ b/deployment/schema.json
@@ -102,6 +102,11 @@
       "default": false,
       "type": "boolean"
     },
+    "css.tailwindDirectives": {
+      "description": "Enable parsing of Tailwind CSS 4.0 directives and functions.",
+      "default": false,
+      "type": "boolean"
+    },
     "graphql.enabled": {
       "description": "Enable graphql formatting.",
       "default": false,

--- a/src/configuration/configuration.rs
+++ b/src/configuration/configuration.rs
@@ -99,4 +99,5 @@ pub struct Configuration {
   pub css_css_modules: Option<bool>,
   pub css_grit_metavariables: Option<bool>,
   pub javascript_grit_metavariables: Option<bool>,
+  pub css_tailwind_directives: Option<bool>,
 }

--- a/src/configuration/resolve_config.rs
+++ b/src/configuration/resolve_config.rs
@@ -95,6 +95,7 @@ pub fn resolve_config(
       .or(grit_metavariables),
     javascript_grit_metavariables: get_nullable_value(&mut config, "javascript.gritMetavariables", &mut diagnostics)
       .or(grit_metavariables),
+    css_tailwind_directives: get_nullable_value(&mut config, "css.tailwindDirectives", &mut diagnostics),
   };
 
   diagnostics.extend(get_unknown_property_diagnostics(config));

--- a/src/format_text.rs
+++ b/src/format_text.rs
@@ -104,7 +104,7 @@ pub fn format_text(file_path: &Path, input_text: &str, config: &Configuration) -
             CssModulesKind::None
           },
           grit_metavariables: config.css_grit_metavariables.unwrap_or(false),
-          tailwind_directives: Default::default(),
+          tailwind_directives: config.css_tailwind_directives.unwrap_or(false),
         },
       );
       if tree.has_errors() {

--- a/tests/specs/CssTailwind.txt
+++ b/tests/specs/CssTailwind.txt
@@ -1,0 +1,19 @@
+-- file.css --
+~~ css.enabled: true, css.tailwindDirectives: true ~~
+== should format css with tailwind directives ==
+@theme {
+  --color-primary:   oklch(0.5 0.1 200);
+}
+
+@utility tab-4 {
+  tab-size:4;
+}
+
+[expect]
+@theme {
+	--color-primary: oklch(0.5 0.1 200);
+}
+
+@utility tab-4 {
+	tab-size: 4;
+}


### PR DESCRIPTION
The CSS parser rejects Tailwind v4 syntax, and there's no way to allow it: `tailwind_directives` is hardcoded to the default.

Adds `css.tailwindDirectives`.