### PR TITLE
chore: fix CHECK_COMMANDS temporal dead zone error

### DIFF
--- a/scripts/update.ts
+++ b/scripts/update.ts
@@ -85,7 +85,7 @@ await $`git push origin ${newVersion}`;
 // CI log live while also capturing it so a failure can be handed to the AI.
 async function runChecks(): Promise<{ passed: boolean; output: string }> {
   const results = [];
-  for (const command of CHECK_COMMANDS) {
+  for (const command of checkCommands()) {
     results.push(await capture(command()));
   }
   const failures = results.filter((r) => r.code !== 0);
@@ -106,16 +106,20 @@ function capture(command: ReturnType<typeof $>) {
 // same checks as `runChecks`, but throws on the first failure so the workflow
 // aborts before anything is committed, tagged, or published.
 async function assertChecks(): Promise<void> {
-  for (const command of CHECK_COMMANDS) {
+  for (const command of checkCommands()) {
     await command();
   }
 }
 
-const CHECK_COMMANDS = [
-  () => $`cargo test`,
-  () => $`cargo clippy --all-targets --all-features -- -D warnings`,
-  () => $`cargo build --target wasm32-unknown-unknown --features wasm --release`,
-];
+// a function (not a top-level const) so it is hoisted -- `runChecks` is called
+// from top-level code above before a const declared here would be initialized.
+function checkCommands() {
+  return [
+    () => $`cargo test`,
+    () => $`cargo clippy --all-targets --all-features -- -D warnings`,
+    () => $`cargo build --target wasm32-unknown-unknown --features wasm --release`,
+  ];
+}
 
 function getBiomeCargoTomlTag(text: string) {
   const match = text.match(/git = \"https:\/\/github.com\/biomejs\/biome\", tag = \"([^\"]+)\"/);


### PR DESCRIPTION
The update script fails immediately on every run with:

```
ReferenceError: Cannot access 'CHECK_COMMANDS' before initialization
  for (const command of CHECK_COMMANDS) {
```

`runChecks()` is called from top-level code, but `CHECK_COMMANDS` was a `const` declared *below* that call. Unlike `function` declarations, `const` isn't hoisted — it's in the temporal dead zone until its line runs, which the top-level `await runChecks()` reaches first.

Fix: make it a hoisted `function checkCommands()` so declaration order no longer matters (keeps the newspaper ordering with helpers at the bottom).

Introduced in #30. The same fix is going out for dprint-plugin-mago and dprint-plugin-oxc.